### PR TITLE
Update script to accommodate M1 Macs

### DIFF
--- a/installfest_pcl.bash
+++ b/installfest_pcl.bash
@@ -4,6 +4,12 @@
 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+if [ $(uname -m) == arm64 ]
+then
+  echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> /Users/$(whoami)/.zprofile
+  eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
 # Then install python
 brew install python
 


### PR DESCRIPTION
The purpose of this PR is to add commands that will accommodate M1 Macs. Currently, the script fails for M1 Macs because the path where Homebrew is installed is not in the default Mac path. 

This fix is intended to write the /opt location into the user's .zprofile for those with M1 Macs.

More info can be found [here](https://app.asana.com/0/1201700438643002/1202795997185484/f).